### PR TITLE
Refactor methods in NoteableClient

### DIFF
--- a/origami/client.py
+++ b/origami/client.py
@@ -191,7 +191,9 @@ class NoteableClient(httpx.AsyncClient):
         resp.raise_for_status()
         return NotebookFile.parse_raw(resp.content)
 
-    async def get_kernel_session(self, file: Union[UUID, NotebookFile]) -> Optional[KernelStatusUpdate]:
+    async def get_kernel_session(
+        self, file: Union[UUID, NotebookFile]
+    ) -> Optional[KernelStatusUpdate]:
         """Fetches the first notebook kernel session via the Noteable REST API.
         Returns None if no session is active.
         """
@@ -200,7 +202,9 @@ class NoteableClient(httpx.AsyncClient):
         resp.raise_for_status()
         resp_data = resp.json()
         if resp_data:
-            session = KernelStatusUpdate(session_id=resp_data[0]["id"], kernel=resp_data[0]["kernel"])
+            session = KernelStatusUpdate(
+                session_id=resp_data[0]["id"], kernel=resp_data[0]["kernel"]
+            )
             self.file_session_cache[file_id] = session
             return session
 
@@ -268,9 +272,7 @@ class NoteableClient(httpx.AsyncClient):
         return session
 
     @_default_timeout_arg
-    async def delete_kernel_session(
-        self, file: Union[UUID, NotebookFile], timeout: float = None
-    ):
+    async def delete_kernel_session(self, file: Union[UUID, NotebookFile], timeout: float = None):
         """Fetches the first notebook kernel session via the Noteable REST API.
         Returns None if no session is active.
         """
@@ -281,7 +283,9 @@ class NoteableClient(httpx.AsyncClient):
             session = await self.get_kernel_session(file)
         if session is None:
             return  # Already shutdown
-        resp = await self.delete(f"{self.api_server_uri}/sessions/{session.session_id}", timeout=timeout)
+        resp = await self.delete(
+            f"{self.api_server_uri}/sessions/{session.session_id}", timeout=timeout
+        )
         resp.raise_for_status()
         if file_id in self.file_session_cache:
             del self.file_session_cache[file.id]

--- a/origami/client.py
+++ b/origami/client.py
@@ -237,7 +237,7 @@ class NoteableClient(httpx.AsyncClient):
         If no session is available one is created, if one is available but not ready it awaits the kernel session
         being ready for further requests.
         """
-        resp = await self.subscribe_file(file, timeout=launch_timeout)
+        resp = await self.subscribe_file(file)
         assert resp.data.success, "Failed to connect to the files channel over RTU"
         session = resp.data.kernel_session
         if not session:

--- a/origami/types/access_levels.py
+++ b/origami/types/access_levels.py
@@ -63,6 +63,7 @@ class AccessLevelAction(enum.Enum):
     execute_cell = enum.auto()
     connect_kernel = enum.auto()
     create_file_version = enum.auto()
+    create_file_sandbox = enum.auto()
 
     # NotebookFile comment actions
     view_comments = enum.auto()

--- a/origami/types/kernels.py
+++ b/origami/types/kernels.py
@@ -230,22 +230,6 @@ class KernelRequestDetails(BaseModel):
     metadata: Optional[KernelRequestMetadata] = None
 
 
-class SessionDetails(BaseModel):
-    """Outlines the response payload for a sessions API request."""
-
-    id: str = None
-    name: str = ''  # Also unused in source - always set to '' in jupyter land
-    path: str
-    type: FileType = FileType.notebook  # Unused in source? Nteract only ever sends "notebook", too
-    kernel: KernelDetails
-    notebook: NotebookDetails = None
-
-    @property
-    def kernel_channel(self):
-        """Helper to build kernel channel names for subscriptions"""
-        return f"kernels/{self.kernel.id}"
-
-
 class SessionRequestDetails(BaseModel):
     """Represents a SessionRequest form that asks about a notebook / kernel session."""
 

--- a/origami/types/rtu.py
+++ b/origami/types/rtu.py
@@ -182,6 +182,11 @@ class KernelStatusUpdate(BaseModel):
     kernel: KernelDetails
     metadata: Optional[dict] = None
 
+    @property
+    def kernel_channel(self):
+        """Helper to build kernel channel names for subscriptions"""
+        return f"kernels/{self.kernel.id}"
+
 
 class FileSubscriptionUser(BaseModel):
     """The type information for users actively viewing a shared subscription (e.g. file)"""


### PR DESCRIPTION
## Summary of changes
- use `KernelStatusUpdate` as the type for the cached `session` object instead of `SessionDetails`.

## Proof that it works

Following test passes locally against integration. It will be added to the repo soon.

```python
async def test_origami():
    token = 'ey...'
    file_id = '...'
    client = NoteableClient(token, config=ClientConfig(domain='app.noteable-integration.us'))
    async with client:
        file = await client.get_notebook(file_id)
        await client.ping_rtu()
        await client.get_or_launch_ready_kernel_session(file)
        await asyncio.sleep(2)
        await client.execute(file, cell_id="54551ae9-e6e1-40d1-aeb3-b7016e91396c")
        await asyncio.sleep(2)
        await client.delete_kernel_session(file, timeout=20)
        await asyncio.sleep(2)
        await client.delete_kernel_session(file, timeout=20)
        assert await client.get_kernel_session(file) is None
```
<img width="1439" alt="Screen Shot 2022-08-01 at 4 54 04 PM" src="https://user-images.githubusercontent.com/39169550/182252632-b5abcc4d-99f1-475b-a5bc-0642bb326e62.png">

