### PR TITLE
Fix `SessionRequestDetails.generate_file_request` handling of file paths with folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 
 # Ignore noteable app settings
 .noteable_config
+
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `SessionRequestDetails.generate_file_request` handling of file paths with folders
+
 ## [0.0.2] - 2022-08-02
 ### Changed
 - Change `name` in pyproject.toml from `origami` to `noteable-origami`

--- a/origami/tests/types/test_kernels.py
+++ b/origami/tests/types/test_kernels.py
@@ -1,0 +1,55 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from origami.types.access_levels import Visibility
+from origami.types.files import FileType, NotebookFile
+from origami.types.kernels import SessionRequestDetails
+
+
+@pytest.fixture()
+def file():
+    project_id = uuid.uuid4()
+    return NotebookFile(
+        id=uuid.uuid4(),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        project_id=project_id,
+        filename="hello world.ipynb",
+        path="folder/hello world.ipynb",
+        type=FileType.notebook,
+        created_by_id=uuid.uuid4(),
+        visibility=Visibility.private,
+        is_playground_mode_file=False,
+        space_id=uuid.uuid4(),
+        file_store_path=f"{project_id}/folder/hello world.ipynb",
+        content={"metadata": {}},
+    )
+
+
+class TestSessionRequestDetails:
+    def test_generate_file_request(self, file):
+        session_request = SessionRequestDetails.generate_file_request(file)
+        assert session_request.path == f'{file.project_id}/{file.path}'
+        assert session_request.type == FileType.notebook
+        assert session_request.kernel.name == 'python3'
+        assert session_request.kernel.metadata.hardware_size_identifier is None
+
+    def test_generate_file_request_with_metadata(self, file):
+        file = file.copy(
+            update={
+                "content": {
+                    "metadata": {
+                        "kernel_info": {
+                            "name": "r",
+                        },
+                        "selected_hardware_size": "small",
+                    }
+                }
+            }
+        )
+        session_request = SessionRequestDetails.generate_file_request(file)
+
+        assert session_request.kernel.name == 'r'
+        assert session_request.kernel.metadata.hardware_size_identifier == 'small'

--- a/origami/types/kernels.py
+++ b/origami/types/kernels.py
@@ -253,11 +253,9 @@ class SessionRequestDetails(BaseModel):
         metadata = file.json_contents['metadata']
         kernel_name = kernel_name or metadata.get('kernel_info', {}).get('name', 'python3')
         hardware_size = hardware_size or metadata.get('selected_hardware_size')
-        request_metadata = (
-            KernelRequestMetadata(hardware_size_identifier=hardware_size) if hardware_size else None
-        )
+        request_metadata = KernelRequestMetadata(hardware_size_identifier=hardware_size)
         return SessionRequestDetails(
-            path=f'{file.project_id}/{file.filename}',
-            type='notebook',
+            path=f'{file.project_id}/{file.path}',
+            type=FileType.notebook,
             kernel=KernelRequestDetails(name=kernel_name, metadata=request_metadata),
         )


### PR DESCRIPTION
This method previously was not taking into account paths with folders since it was just using `file.filename` rather than `file.path`