### PR TITLE
Fix race condition of subscribe_reply processing

### DIFF
--- a/origami/client.py
+++ b/origami/client.py
@@ -536,7 +536,7 @@ class NoteableClient(httpx.AsyncClient):
             # before the subscribe_reply (for e.g. update_user_file_subscription_event)
             if resp.event != "subscribe_reply":
                 raise SkipCallback("This callback only processes subscribe_reply")
-            GenericRTUReplySchema[TopicActionReplyData].parse_obj(resp)
+            resp = GenericRTUReplySchema[TopicActionReplyData].parse_obj(resp)
             if resp.data.success:
                 self.subscriptions.add(resp.channel)
             else:

--- a/origami/client.py
+++ b/origami/client.py
@@ -536,7 +536,7 @@ class NoteableClient(httpx.AsyncClient):
             # before the subscribe_reply (for e.g. update_user_file_subscription_event)
             if resp.event != "subscribe_reply":
                 raise SkipCallback("This callback only processes subscribe_reply")
-
+            GenericRTUReplySchema[TopicActionReplyData].parse_obj(resp)
             if resp.data.success:
                 self.subscriptions.add(resp.channel)
             else:


### PR DESCRIPTION
When a subscribe_request is sent out with a particular transaction id, multiple events can be fired off in response with the same transaction id, namely `subscribe_reply`, `update_user_file_subscription_event`, `remove_user_file_subscription_event` (and more maybe?).

The RTU message processing loop in `origami` is built in such a way that if the `subscribe_reply` is the first one to be processed, the `tracker` object for that transaction id is correctly processed and subsequently discarded. However, due to the wonderful world of distributed systems and latency, if any of the other events arrive first and get processed, the tracker throws an error since the schema validation fails unconditionally and breaks the loop. This PR allows more control to the `subscribe_reply` user callback to validate the schema.