### PR TITLE
Release 0.0.4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.3
+current_version = 0.0.4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = 
 	{major}.{minor}.{patch}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.0.4] - 2022-09-09
 ### Added
 - Support loading JWT token from `NOTEABLE_TOKEN` environment variable.
 - Support loading API domain from `NOTEABLE_URL` or `NOTEABLE_DOMAIN` environment variable.
+- Add `create_parameterized_notebook` method to `NoteableClient`
+- Add `create_job_instance` method to `NoteableClient`
 
 ## [0.0.3] - 2022-09-02
 ### Fixed

--- a/origami/_version.py
+++ b/origami/_version.py
@@ -1,1 +1,1 @@
-version = "0.0.3"
+version = "0.0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.poetry]
 name = "noteable-origami"
-version = "0.0.3"
+version = "0.0.4"
 description = "The Noteable API interface"
 authors = ["Matt Seal <matt@noteable.io>"]
 maintainers = ["Matt Seal <matt@noteable.io>"]


### PR DESCRIPTION
### Added
- Support loading JWT token from `NOTEABLE_TOKEN` environment variable.
- Support loading API domain from `NOTEABLE_URL` or `NOTEABLE_DOMAIN` environment variable.
- Add `create_parameterized_notebook` method to `NoteableClient`
- Add `create_job_instance` method to `NoteableClient`