### PR TITLE
Add types for display handler updates

### DIFF
--- a/origami/types/rtu.py
+++ b/origami/types/rtu.py
@@ -262,9 +262,7 @@ class OutputType(enum.Enum):
     update_display_data = enum.auto()
 
 
-class OutputContent(BaseModel):
-    """The type class holding the contents of an output from the parent message type."""
-
+class KernelOutputContent(BaseModel):
     raw: Optional[str] = None
     url: Optional[str] = None
     mimetype: str
@@ -287,8 +285,8 @@ class OutputData(NoteableAPIModel):
     type: OutputType
     display_id: Optional[str]
     available_mimetypes: List[str]
-    content_metadata: OutputContent
-    content: Optional[OutputContent]
+    content_metadata: KernelOutputContent
+    content: Optional[KernelOutputContent]
     parent_collection_id: UUID
 
 
@@ -335,12 +333,6 @@ class KernelOutputType(enum.Enum):
     error = enum.auto()
     clear_output = enum.auto()
     update_display_data = enum.auto()
-
-
-class KernelOutputContent(BaseModel):
-    raw: Optional[str] = None
-    url: Optional[str] = None
-    mimetype: str
 
 
 class KernelOutput(NoteableAPIModel):

--- a/origami/types/rtu.py
+++ b/origami/types/rtu.py
@@ -369,6 +369,32 @@ UpdateOutputCollectionEventSchema = GenericRTUReplySchema[KernelOutputCollection
 AppendOutputEventSchema = GenericRTUReplySchema[KernelOutput]
 
 
+class OutputMetadata(BaseModel):
+    raw: Optional[Dict[str, Any]] = None
+    storage_path: Optional[str] = None
+    url: Optional[str] = None
+
+    @root_validator
+    def only_accept_one_not_both(cls, values: dict):
+        has_raw_and_storage_path = all([values.get("raw"), values.get("storage_path")])
+        has_raw_and_url = all([values.get("raw"), values.get("url")])
+        if has_raw_and_storage_path or has_raw_and_url:
+            raise ValueError(
+                "Either `raw` should be provided, or `storage_path`/`url` -- not `raw` and `storage_path`/`url`"
+            )
+        return values
+
+
+class DisplayHandlerUpdate(BaseModel):
+    output_ids: List[str]
+    content: KernelOutputContent
+    available_mimetypes: List[str]
+    metadata: OutputMetadata = OutputMetadata()
+
+
+DisplayHandlerUpdateEventSchema = GenericRTUReplySchema[DisplayHandlerUpdate]
+
+
 @enum.unique
 class KernelStatus(enum.Enum):
     """The enumerable defining all the possible kernel states one can land in.


### PR DESCRIPTION
This is needed so that all types of Noteable output RTU messages can be parsed by papermill-origami. 

Re: https://github.com/noteable-io/papermill-origami/pull/50