### PR TITLE
Remove `NOTEABLE_URI`

### DIFF
--- a/origami/client.py
+++ b/origami/client.py
@@ -144,9 +144,7 @@ class NoteableClient(httpx.AsyncClient):
                 config = ClientConfig.parse_file(settings.auth0_config_path)
 
         self.config = config
-        self.config.domain = os.getenv(
-            "NOTEABLE_URI", os.getenv("NOTEABLE_DOMAIN", self.config.domain)
-        )
+        self.config.domain = os.getenv("NOTEABLE_DOMAIN", self.config.domain)
         self.file_session_cache = {}
 
         self.user = None

--- a/origami/tests/test_client.py
+++ b/origami/tests/test_client.py
@@ -82,9 +82,8 @@ def test_token_is_loaded_from_env(client_config):
     assert client.token.access_token == "fake-token-env"
 
 
-@pytest.mark.parametrize("env_name", ["NOTEABLE_URI", "NOTEABLE_DOMAIN"])
 def test_domain_is_loaded_from_env(client_config, env_name):
-    os.environ[env_name] = "https://example.com"
+    os.environ["NOTEABLE_DOMAIN"] = "https://example.com"
     client = NoteableClient(config=client_config)
     assert client.config.domain == "https://example.com"
 

--- a/origami/tests/test_client.py
+++ b/origami/tests/test_client.py
@@ -82,7 +82,7 @@ def test_token_is_loaded_from_env(client_config):
     assert client.token.access_token == "fake-token-env"
 
 
-def test_domain_is_loaded_from_env(client_config, env_name):
+def test_domain_is_loaded_from_env(client_config):
     os.environ["NOTEABLE_DOMAIN"] = "https://example.com"
     client = NoteableClient(config=client_config)
     assert client.config.domain == "https://example.com"


### PR DESCRIPTION
We have `NOTEABLE_URI` set as domain for backwards compatibility, but this can be removed now.