### PR TITLE
Add `update_job_instance_attempt` to AccessLevelAction enum

### DIFF
--- a/origami/defs/access_levels.py
+++ b/origami/defs/access_levels.py
@@ -72,6 +72,7 @@ class AccessLevelAction(enum.Enum):
     read_job_definitions = enum.auto()
     update_job_definition = enum.auto()
     delete_job_definition = enum.auto()
+    update_job_instance_attempt = enum.auto()
 
     # NotebookFile comment actions
     view_comments = enum.auto()


### PR DESCRIPTION
origami API response validation breaks when schemas used in Gate and here differ. 

This PR adds `update_job_instance_attempt` to the `AccessLevelActions` enum to ensure the enum is synced with Gate.