### PR TITLE
Remove playground mode field

### DIFF
--- a/origami/defs/files.py
+++ b/origami/defs/files.py
@@ -181,7 +181,6 @@ class NotebookFile(FileRBACModel):
     visibility: Visibility
     visibility_default_access_level: Optional[AccessLevel]
     source_file_id: Optional[UUID]
-    is_playground_mode_file: bool
     space_id: UUID
     project_user_access_level: Optional[AccessLevel]
     space_user_access_level: Optional[AccessLevel]

--- a/origami/tests/defs/test_kernels.py
+++ b/origami/tests/defs/test_kernels.py
@@ -21,7 +21,6 @@ def file():
         type=FileType.notebook,
         created_by_id=uuid.uuid4(),
         visibility=Visibility.private,
-        is_playground_mode_file=False,
         space_id=uuid.uuid4(),
         file_store_path=f"{project_id}/folder/hello world.ipynb",
         content={"metadata": {}},


### PR DESCRIPTION
We recently made an API change in Noteable backend and no longer return the `is_playground_mode_file` field as part of a GET file response.