### PR TITLE
Add RTU client type to auth request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `rtu_client_type` to `authenticate_request`
+
 ## [0.0.29] - 2023-05-30
 ### Fixed
 - Don't send file subscribe requests by delta id all-0's (sentinel value), it's not a real Delta in the db

--- a/origami/defs/rtu.py
+++ b/origami/defs/rtu.py
@@ -505,10 +505,25 @@ class ProjectFilesSyncedMessage(BaseModel):
     pass
 
 
+@enum.unique
+class RTUClientTypes(str, enum.Enum):
+    UNKNOWN = 'unknown'
+
+    GEAS = 'geas'
+    PLANAR_ALLY = 'planar_ally'
+    ORIGAMI = 'origami'
+    ORIGAMIST = 'origamist'
+
+    def __str__(self):
+        return self.value
+
+
 class AuthenticationRequestData(BaseModel):
     """Defines a request to ping the rtu websocket"""
 
     token: str
+
+    rtu_client_type: Optional[RTUClientTypes] = RTUClientTypes.UNKNOWN
 
 
 class AuthenticationRequest(GenericRTURequestSchema[AuthenticationRequestData]):


### PR DESCRIPTION
Default to `origami` client type, but allow callers to override.