### PR TITLE
fix for list-of-strings on StreamOutput validation

### DIFF
--- a/origami/notebook/model.py
+++ b/origami/notebook/model.py
@@ -23,6 +23,13 @@ class StreamOutput(BaseModel):
     name: str  # stdout or stderr
     text: str
 
+    @validator("text", pre=True)
+    def multiline_text(cls, v):
+        """In the event we get a list of strings, combine into one string with newlines."""
+        if isinstance(v, list):
+            return "\n".join(v)
+        return v
+
 
 class DisplayDataOutput(BaseModel):
     output_type: Literal["display_data"] = "display_data"


### PR DESCRIPTION
Similar to cell `source` validation; if we get a list of strings in StreamOutput.text, combine them into a single string.