### PR TITLE
switch to connect_realtime accepting a file or file ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Python 3.8+
 ## Installation
 
 For stable release:
+
 ```bash
 pip install noteable-origami
 ```
@@ -53,6 +54,7 @@ poetry add noteable-origami
 ```
 
 For alpha pre-release:
+
 ```bash
 pip install noteable-origami --pre
 ```
@@ -64,8 +66,7 @@ pip install noteable-origami --pre
 ## Getting Started
 
 > **Warning**
-Developer note: this documentation is written for the 1.0 alpha release. For stable release, see [pre-1.0 README](https://github.com/noteable-io/origami/blob/release/0.0.35/README.md)
-
+> Developer note: this documentation is written for the 1.0 alpha release. For stable release, see [pre-1.0 README](https://github.com/noteable-io/origami/blob/release/0.0.35/README.md)
 
 ### API Tokens
 
@@ -76,7 +77,7 @@ The Noteable API requires an authentication token. You can manage tokens at the 
 
 ### Usage
 
-The example below shows how to create a Notebook, launch a Kernel, add new cells, and execute code. 
+The example below shows how to create a Notebook, launch a Kernel, add new cells, and execute code.
 
 ```python
 # Grab a project_id from the Noteable UI, the url will look like: app.noteable.io/p/....
@@ -99,15 +100,15 @@ file = await api_client.create_notebook(project_id=project_id, path="Demo.ipynb"
 await api_client.launch_kernel(file.id)
 
 # Client for Real-time Updates (RTU), used with Notebooks
-rtu_client = await api_client.rtu_client(file.id)
+realtime_notebook = await api_client.connect_realtime(file)
 
 # Add a new cell
 from origami.models.notebook import CodeCell
 cell = CodeCell(source="print('Hello World')")
-await rtu_client.add_cell(cell)
+await realtime_notebook.add_cell(cell)
 
 # Execute the cell
-queued_execution = await rtu_client.queue_execution(cell.id)
+queued_execution = await realtime_notebook.queue_execution(cell.id)
 
 # Wait for the execution to be complete, cell is an updated instance of CodeCell with metadata/outputs
 cell = await queued_execution
@@ -117,9 +118,7 @@ output_collection = await api_client.get_output_collection(cell.output_collectio
 print(output_collection.outputs[0].content.raw) # 'Hello World\n'
 ```
 
-
 <!-- --8<-- [end:start] -->
-
 
 ## 1.0 Roadmap
 
@@ -130,6 +129,7 @@ Origami is heading towards a 1.0 release. The alpha release candidate is on Pypi
 See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ---
+
 <p align="center">Open sourced with ❤️ by <a href="https://noteable.io">Noteable</a> for the community.</p>
 
 <img href="https://pages.noteable.io/private-beta-access" src="https://assets.noteable.io/github/2022-07-29/noteable.png" alt="Boost Data Collaboration with Notebooks">

--- a/tests/rtu/test_execution.py
+++ b/tests/rtu/test_execution.py
@@ -14,7 +14,7 @@ async def test_single_cell(api_client: APIClient, notebook_maker):
     # TODO: remove sleep when Gate stops permission denied on newly created files (db time-travel)
     await asyncio.sleep(2)
 
-    rtu_client: RTUClient = await api_client.rtu_client(file.id)
+    rtu_client: RTUClient = await api_client.connect_realtime(file)
     assert rtu_client.builder.nb.cells == notebook.cells
 
     kernel_session: KernelSession = await api_client.launch_kernel(file.id)
@@ -47,7 +47,7 @@ async def test_run_all(api_client: APIClient, notebook_maker):
     # TODO: remove sleep when Gate stops permission denied on newly created files (db time-travel)
     await asyncio.sleep(2)
 
-    rtu_client: RTUClient = await api_client.rtu_client(file.id)
+    rtu_client: RTUClient = await api_client.connect_realtime(file)
     assert rtu_client.builder.nb.cells == notebook.cells
 
     kernel_session: KernelSession = await api_client.launch_kernel(file.id)

--- a/tests/rtu/test_notebook.py
+++ b/tests/rtu/test_notebook.py
@@ -13,7 +13,7 @@ async def test_add_and_remove_cell(api_client: APIClient, notebook_maker):
     file: File = await notebook_maker()
     # TODO: remove sleep when Gate stops permission denied on newly created files (db time-travel)
     await asyncio.sleep(2)
-    rtu_client: RTUClient = await api_client.rtu_client(file.id)
+    rtu_client: RTUClient = await api_client.connect_realtime(file)
     assert rtu_client.builder.nb.cells == []
 
     cell = CodeCell(id='cell_1', source='print("hello world")')


### PR DESCRIPTION
This PR introduces two API changes to `origami`'s 1.0.0 alpha.

1. **Action Oriented RTU Client Creation**: The method formerly known as `api_client.rtu_client has been renamed to api_client.connect_realtime. This change shifts the focus from what the method returns (a noun) to what the method does (an action).

2. **Flexible File Input**: `connect_realtime` has been updated to accept any of a `File` object directly, a `file_id` as a string, or a `file_id` as a UUID.

```python
file = await api_client.create_notebook("Untitled67.ipynb")
rtu_client: RTUClient = await api_client.connect_realtime(file)
```

I've added some error handling and updated the tests to match.