### PR TITLE
Always return list of futures on queue_execution, guard against executing empty code cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For pre-1.0 releases, see [0.0.35 Changelog](https://github.com/noteable-io/orig
 - `rtu_client.change_cell_type` to switch between code, markdown, and sql cells
 
 ### Changed
- - `rtu_client.queue_execution` will always return a list of Futures, even on single cell execution. Also guards against executing empty code cells
+ - `rtu_client.queue_execution` will always return a dict of {Future: cell_id}, even on single cell execution. Also guards against executing empty code cells
 
 ## [1.0.0-alpha.2] - 2023-07-26
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ For pre-1.0 releases, see [0.0.35 Changelog](https://github.com/noteable-io/orig
 - `origami.models.notebook.make_sql_cell` convenience function, returns a `CodeCell` with appropriate metadata
 - `rtu_client.change_cell_type` to switch between code, markdown, and sql cells
 
+### Changed
+ - `rtu_client.queue_execution` will always return a list of Futures, even on single cell execution. Also guards against executing empty code cells
+
 ## [1.0.0-alpha.2] - 2023-07-26
 ### Changed
 - `api_client.rtu_client` method renamed to `api_client.connect_realtime`, can accept `File` model in addition to `str` / `UUID`

--- a/origami/clients/rtu.py
+++ b/origami/clients/rtu.py
@@ -10,7 +10,7 @@ import random
 import string
 import traceback
 import uuid
-from typing import Awaitable, Callable, Dict, List, Literal, Optional, Type, Union
+from typing import Awaitable, Callable, Dict, List, Literal, Optional, Type
 
 import orjson
 from pydantic import BaseModel, parse_obj_as
@@ -828,30 +828,23 @@ class RTUClient:
         before_id: Optional[str] = None,
         after_id: Optional[str] = None,
         run_all: bool = False,
-    ) -> Union[asyncio.Future[CodeCell], List[asyncio.Future[CodeCell]]]:
+    ) -> List[asyncio.Future[CodeCell]]:
         """
-        Execute an individual cell or multiple cells in the Notebook. The return value is a single
-        Future or list of Futures that will resolve to the CodeCell executed when the cell has
-        finished running.
+        Execute an individual cell or multiple cells in the Notebook. The return value is always
+        a list of Futures, even if only one cell is being executed.
+
          - Only code Cells can be executed. When running multiple cells with before / after / all
            non-code cells will be excluded automatically
+         - Code cells with no source are not executed on Noteable backend, so they'll be skipped
          - Outputs should be available from the cell.output_collection_id property.
         """
-        # Single cell flow, return a single Future
-        if cell_id:
-            idx, cell = self.builder.get_cell(cell_id)  # can raise CellNotFound
-            if cell.cell_type != 'code':
-                raise ValueError("Can only queue execute on code cells")
-            future = asyncio.Future()
-            self._execute_cell_events[cell_id] = future
-            delta = CellExecute(file_id=self.file_id, resource_id=cell_id)
-            await self.new_delta_request(delta)
-            return future
-
-        # Multiple cell flow
-        if not before_id and not after_id and not run_all:
+        if not cell_id and not before_id and not after_id and not run_all:
             raise ValueError("One of cell_id, before_id, after_id, or run_all must be set.")
-        if before_id:
+
+        if cell_id:
+            cell_ids = [cell_id]
+            delta = CellExecute(file_id=self.file_id, resource_id=cell_id)
+        elif before_id:
             idx, cell = self.builder.get_cell(before_id)  # can raise CellNotFound
             cell_ids = self.cell_ids[: idx + 1]  # inclusive of the "before_id" cell
             delta = CellExecuteBefore(file_id=self.file_id, resource_id=before_id)
@@ -864,10 +857,11 @@ class RTUClient:
             delta = CellExecuteAll(file_id=self.file_id)
         futures = []
         for cell_id in cell_ids:
-            # Only create futures for Code cells
+            # Only create futures for Code cells that have something in source. Otherwise the cell
+            # will never get executed by PA/Kernel, so we'd never see cell status and resolve future
             future = asyncio.Future()
             idx, cell = self.builder.get_cell(cell_id)
-            if cell.cell_type == 'code':
+            if cell.cell_type == 'code' and cell.source.strip():
                 self._execute_cell_events[cell_id] = future
                 futures.append(future)
         await self.new_delta_request(delta)

--- a/tests/e2e/rtu/test_execution.py
+++ b/tests/e2e/rtu/test_execution.py
@@ -22,7 +22,8 @@ async def test_single_cell(api_client: APIClient, notebook_maker):
 
     queued_execution = await rtu_client.queue_execution('cell_1')
     # Assert cell_1 output collection has multiple outputs
-    cell: CodeCell = await queued_execution  # wait for cell_1 to be done
+    cell_1_fut = list(queued_execution)[0]
+    cell: CodeCell = await cell_1_fut  # wait for cell_1 to be done
     output_collection: KernelOutputCollection = await api_client.get_output_collection(
         cell.output_collection_id
     )


### PR DESCRIPTION
Dealing with a single future or list of futures proved to be a poor dev experience in Origamist. Switching to a single return type even in the case of single cell id. I also found myself wanting a reference to cell ids for use cases like `done, pending = await asyncio.wait(queued_execution, timeout=5)` -> `pending_cell_ids = [queued_execution[f] for f in pending]`