### PR TITLE
add optional `content_for_llm` attribute for KernelOutput

### DIFF
--- a/origami/models/api/outputs.py
+++ b/origami/models/api/outputs.py
@@ -18,6 +18,7 @@ class KernelOutput(ResourceBase):
     available_mimetypes: List[str]
     content_metadata: KernelOutputContent
     content: Optional[KernelOutputContent]
+    content_for_llm: Optional[KernelOutputContent]
     parent_collection_id: uuid.UUID
 
 


### PR DESCRIPTION
If the Noteable backend API provides `content_for_llm` based on available richest media types, we'll need to make sure the modeling can use it for client consumption