### PR TITLE
add build.os for readthedocs deployment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os
 build:
-  os: ubuntu-20.04
+   os: ubuntu-20.04
 
 # Build documentation in the docs/ directory with mkdocs
 mkdocs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,10 @@
 # Required
 version: 2
 
+# https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os
+build:
+  os: ubuntu-20.04
+
 # Build documentation in the docs/ directory with mkdocs
 mkdocs:
    configuration: mkdocs.yml


### PR DESCRIPTION
![image](https://github.com/noteable-io/origami/assets/7707189/f619b148-2da3-4672-8555-c68229204449)
