### PR TITLE
add readthedocs `build.tools`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,8 @@ version: 2
 # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os
 build:
    os: ubuntu-20.04
+   tools:
+     python: "3.9"
 
 # Build documentation in the docs/ directory with mkdocs
 mkdocs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
    os: ubuntu-20.04
    tools:
-     python: "3.9"
+      python: "3.9"
 
 # Build documentation in the docs/ directory with mkdocs
 mkdocs:


### PR DESCRIPTION
since https://github.com/noteable-io/origami/pull/179 wasn't enough

![image](https://github.com/noteable-io/origami/assets/7707189/2399e2e9-944e-4b79-b07f-f2e9c64a9f52)
